### PR TITLE
register current tab's url and title as bookmark.

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,8 @@
   "description": "Load a random page from your bookmarks!",
   "permissions": [
     "bookmarks",
-    "storage"
+    "storage",
+    "tabs"
   ],
   "commands": {
     "save": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,26 +72,17 @@ var createWebmarkFolder = (): void => {
     )
 };
 
-// type checker for proper string type url
-let typeCheckString = (text: string | undefined): string => {
-    if (text == undefined) {
-        // TODO: this block needs proper type guard rather than returning below url.
-        return "https://example.com/error";
-    } else {
-        return text;
-    }
-};
-
 let getCurrentUrlAndSave = () => {
     chrome.tabs.query(
         { active: true, currentWindow: true },
         ([currentTab]) => {
             const thisTabUrl: string|undefined = currentTab.url;
+
             const thisTabTitle: string|undefined = currentTab.title;
+
             saveToWebmarkFolder(thisTabUrl, thisTabTitle);
         });
 }
-
 
 var saveToWebmarkFolder = (url: string|undefined, title: string|undefined): void => {
 
@@ -102,7 +93,6 @@ var saveToWebmarkFolder = (url: string|undefined, title: string|undefined): void
     if (title == undefined) {
         title = "read later";
     }
-
 
     chrome.storage.sync.get(
         ['webmarkFolderId'],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,11 +74,11 @@ var createWebmarkFolder = (): void => {
 
 // type checker for proper string type url
 let typeCheckString = (text: string | undefined): string => {
-    if (text != undefined) {
-        return text;
-    } else {
+    if (text == undefined) {
         // TODO: this block needs proper type guard rather than returning below url.
         return "https://example.com/error";
+    } else {
+        return text;
     }
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,15 +86,24 @@ let getCurrentUrlAndSave = () => {
     chrome.tabs.query(
         { active: true, currentWindow: true },
         ([currentTab]) => {
-            const thisTabUrl: string = typeCheckString(currentTab.url);
-            const thisTabTitle: string = typeCheckString(currentTab.title);
+            const thisTabUrl: string|undefined = currentTab.url;
+            const thisTabTitle: string|undefined = currentTab.title;
             saveToWebmarkFolder(thisTabUrl, thisTabTitle);
         });
 }
 
 
+var saveToWebmarkFolder = (url: string|undefined, title: string|undefined): void => {
 
-var saveToWebmarkFolder = (url: string, title: string): void => {
+    //TODO: find better way to sanitize input 
+    if (url == undefined) {
+        url= "https://example.com/error";
+    } 
+    if (title == undefined) {
+        title = "read later";
+    }
+
+
     chrome.storage.sync.get(
         ['webmarkFolderId'],
         function (result?) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,8 @@ import Popup from './components/Popup';
 // // unregister() to register() below. Note this comes with some pitfalls.
 // // Learn more about service workers: https://bit.ly/CRA-PWA
 // serviceWorker.unregister();
-/*global chrome*/ ;
-chrome.storage.sync.clear();
+/*global chrome*/;
+// chrome.storage.sync.clear();
 ReactDOM.render(
     <Popup />,
     document.getElementById('root') as HTMLElement
@@ -25,8 +25,7 @@ var saveClicked = (): void => {
             }
             else {
                 console.log('webmarkFolderId found.');
-                let currentUrl: string = getCurrentUrl();
-                saveToWebmarkFolder(currentUrl);
+                getCurrentUrlAndSave();
             };
         }
     );
@@ -73,11 +72,29 @@ var createWebmarkFolder = (): void => {
     )
 };
 
-var getCurrentUrl = (): string => {
-    return 'https://current.url.com';
+// type checker for proper string type url
+let typeCheckString = (text: string | undefined): string => {
+    if (text != undefined) {
+        return text;
+    } else {
+        // TODO: this block needs proper type guard rather than returning below url.
+        return "https://example.com/error";
+    }
 };
 
-var saveToWebmarkFolder = (url: string): void => {
+let getCurrentUrlAndSave = () => {
+    chrome.tabs.query(
+        { active: true, currentWindow: true },
+        ([currentTab]) => {
+            const thisTabUrl: string = typeCheckString(currentTab.url);
+            const thisTabTitle: string = typeCheckString(currentTab.title);
+            saveToWebmarkFolder(thisTabUrl, thisTabTitle);
+        });
+}
+
+
+
+var saveToWebmarkFolder = (url: string, title: string): void => {
     chrome.storage.sync.get(
         ['webmarkFolderId'],
         function (result?) {
@@ -96,6 +113,7 @@ var saveToWebmarkFolder = (url: string): void => {
                                 {
                                     'parentId': webmarkFolderId,
                                     'url': url,
+                                    'title': title,
                                 }
                             );
                             console.log(url + ' saved to folder.');
@@ -115,7 +133,7 @@ var loadHere = (): boolean => {
 }
 
 var getRandomUrlFromFolder = (): string => {
-    return 'https://random.url.com/';
+    return 'https://example.com/random';
 }
 
 var showNotice = (message: string): void => {


### PR DESCRIPTION
- Added function to properly grab current tab's url and title. 
  - note that `chrome.tabs.query` is of return type void and asynchronous. So any operation regarding query results should be done within callback function.
- Granted permission to access tab information in `manifest.json`. 
- Changed placeholder urls to point to `example.com`. 
- Added second parameter for page title to `saveToWebmarkFolder` function. 

