### PR TITLE
Notifications and refactorings

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,7 @@
   "description": "Load a random page from your bookmarks!",
   "permissions": [
     "bookmarks",
+    "notifications",
     "storage",
     "tabs"
   ],

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import PopupButton from "./PopupButton";
+import * as constants from "../constants"
 
 class Popup extends React.Component {
     constructor() {
@@ -11,8 +12,8 @@ class Popup extends React.Component {
     render() {
         return (
             <div className="popup" style={this.popupStyle}>
-                <PopupButton id="save" text="Save this web page" />
-                <PopupButton id="load" text="Load a random web page" />
+                <PopupButton id="save" text={constants.SAVE_BUTTON_TEXT} />
+                <PopupButton id="load" text={constants.LOAD_BUTTON_TEXT} />
             </div>
         );
     }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,0 +1,17 @@
+/** Constant string literals in alphabetical order */
+// IDs and keys (user-invisible strings)
+export const FOLDER_ID_KEY: string = 'webmarkFolderId';
+export const LOAD_HERE_KEY: string = 'loadHere';
+export enum NotificationId {
+    FolderCreated = 'Folder Created',
+    PageAlreadyExists = 'Page Already Exists',
+    FolderNotFound = 'Folder Not Found',
+};
+
+// to be used for i18n later (user-visible strings)
+export const FOLDER_NAME: string = 'WebMark';
+export const FOLDER_NOT_FOUND: string = 'No WebMark folder found, so we just created one. :)';
+export const LOAD_BUTTON_TEXT: string = 'Load a random web page';
+export const PAGE_ALREADY_EXISTS: string = 'The page is already in the folder.';
+export const SAVE_BUTTON_TEXT: string = 'Save this web page';
+// export const SAVE_SUCCESSFUL: string = 'Page saved successfully.';

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -3,15 +3,15 @@
 export const FOLDER_ID_KEY: string = 'webmarkFolderId';
 export const LOAD_HERE_KEY: string = 'loadHere';
 export enum NotificationId {
-    FolderCreated = 'Folder Created',
     PageAlreadyExists = 'Page Already Exists',
-    FolderNotFound = 'Folder Not Found',
+    FolderEmpty = 'Folder Empty',
+    SaveSuccessful = 'Save Successful',
 };
 
 // to be used for i18n later (user-visible strings)
+export const FOLDER_EMPTY: string = 'The folder is empty. Save some pages!';
 export const FOLDER_NAME: string = 'WebMark';
-export const FOLDER_NOT_FOUND: string = 'No WebMark folder found, so we just created one. :)';
 export const LOAD_BUTTON_TEXT: string = 'Load a random web page';
 export const PAGE_ALREADY_EXISTS: string = 'The page is already in the folder.';
 export const SAVE_BUTTON_TEXT: string = 'Save this web page';
-// export const SAVE_SUCCESSFUL: string = 'Page saved successfully.';
+export const SAVE_SUCCESSFUL: string = 'Page was saved successfully.';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,10 @@ var loadClicked = (): void => {
             if (Object.keys(result).length === 0) {
                 console.log('webmarkFolderId not found.');
                 createWebmarkFolder();
+                showNotice(
+                    constants.NotificationId.FolderEmpty,
+                    constants.FOLDER_EMPTY,
+                );
                 return;
             }
             console.log('webmarkFolderId found.');
@@ -64,6 +68,10 @@ var loadClicked = (): void => {
                     if (chrome.runtime.lastError) {
                         console.log('webmark folder not found.');
                         createWebmarkFolder();
+                        showNotice(
+                            constants.NotificationId.FolderEmpty,
+                            constants.FOLDER_EMPTY,
+                        );
                         chrome.storage.sync.remove(constants.FOLDER_ID_KEY);
                         return;
                     }
@@ -92,10 +100,6 @@ var createWebmarkFolder = (callback?: () => void): void => {
                     [constants.FOLDER_ID_KEY]: newFolder.id,
                 }, function () {
                     console.log('set webmarkFolderId to ' + newFolder.id);
-                    showNotice(
-                        constants.NotificationId.FolderCreated,
-                        constants.FOLDER_NOT_FOUND,
-                    );
                     if (callback !== undefined) {
                         callback();
                     }
@@ -154,6 +158,12 @@ var saveToWebmarkFolder = (url: string | undefined, title: string | undefined): 
                                         'parentId': webmarkFolderId,
                                         'url': url,
                                         'title': title,
+                                    },
+                                    () => {
+                                        showNotice(
+                                            constants.NotificationId.SaveSuccessful,
+                                            constants.SAVE_SUCCESSFUL,
+                                        );
                                     }
                                 );
                                 console.log(url + ' saved to folder.');
@@ -161,7 +171,7 @@ var saveToWebmarkFolder = (url: string | undefined, title: string | undefined): 
                             }
                             showNotice(
                                 constants.NotificationId.PageAlreadyExists,
-                                constants.PAGE_ALREADY_EXISTS
+                                constants.PAGE_ALREADY_EXISTS,
                             );
                         }
                     )
@@ -185,10 +195,6 @@ let loadRandomUrlFromFolder = (): void => {
                 () => {
                     if (chrome.runtime.lastError) {
                         console.log('webmark folder not found.');
-                        showNotice(
-                            constants.NotificationId.FolderNotFound,
-                            "Invalid Access"
-                        );
                         return;
                     }
                     let webmarkFolderId: string = result![constants.FOLDER_ID_KEY];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,12 @@ import Popup from './components/Popup';
 // chrome.storage.sync.clear();
 // chrome.storage.sync.set({'loadHere':true});
 
+enum NotificationId {
+    FolderCreated = 'Folder Created',
+    PageAlreadyExists = 'Page Already Exists',
+    FolderNotFound = 'Folder Not Found',
+};
+
 ReactDOM.render(
     <Popup />,
     document.getElementById('root') as HTMLElement
@@ -79,7 +85,11 @@ var createWebmarkFolder = (): void => {
                 }
             );
             console.log('set webmarkFolderId to ' + newFolder.id);
-            showNotice('No WebMark folder found, so we just created one. :)');
+            showNotice(
+                NotificationId.FolderCreated,
+                'No WebMark folder found, so we just created one. :)'
+                ,
+            );
         },
     )
 };
@@ -138,7 +148,10 @@ var saveToWebmarkFolder = (url: string | undefined, title: string | undefined): 
                                 console.log(url + ' saved to folder.');
                                 return;
                             }
-                            showNotice('The page is already in the folder.');
+                            showNotice(
+                                NotificationId.PageAlreadyExists,
+                                'The page is already in the folder.'
+                            );
                         }
                     )
 
@@ -162,7 +175,10 @@ let loadRandomUrlFromFolder = (): void => {
                 () => {
                     if (chrome.runtime.lastError) {
                         console.log('webmark folder not found.');
-                        showNotice("Invalid Access");
+                        showNotice(
+                            NotificationId.FolderNotFound,
+                            "Invalid Access"
+                        );
                         return;
                     }
                     let webmarkFolderId: string = result!['webmarkFolderId'];
@@ -205,8 +221,20 @@ let recursiveUrlCollection = (bookmark: chrome.bookmarks.BookmarkTreeNode, urlLi
     }
 }
 
-var showNotice = (message: string): void => {
-    //TODO: implement showNotice
+var showNotice = (notificationId: NotificationId, title: string, message: string = ''): void => {
+    chrome.notifications.create(
+        notificationId, // prevents duplicate notifcations (only keeps the most recent one)
+        {
+            'type': 'basic', // required
+            'iconUrl': 'images/default.png', // required
+            'title': title, // required
+            'message': message, // required
+            'eventTime': Date.now(),
+        },
+        function (notificationId: string) {
+            console.log(notificationId + ' notification sent.');
+        }
+    );
     console.log('Showed message ("' + message + '") to user.');
 }
 


### PR DESCRIPTION
1. #38, #51
- API: https://developer.chrome.com/apps/notifications
- overview: https://developer.chrome.com/extensions/richNotifications
- `manifest.json`: I added `notifications` in the middle of `permissions` to keep it alphabetical, although I first did it to reduce line changes.
- Edit: Which field in the `notification` do you think we should use? Both `title` and `message` are required, but it's okay to set them as empty strings. I used `title`, but I'm not sure if that's the right choice. Please try both (by modifying the code yourself) and tell me which do you think is better.

2. #42
- I used an optional callback to accomplish this, but I think it might cause an infinite loop.

3. #48: 
- I personally like doing this, having everything in control in one place. I even envy [C# having the empty string as part of the language](https://docs.microsoft.com/en-us/dotnet/api/system.string.empty?view=netframework-4.8).
- it may not be necessary for some string literals.
- `constants.tsx` was divided into two sections because [chrome.i18n API](https://developer.chrome.com/extensions/i18n) tells you to "put all of its user-visible strings into a file named messages.json."
- You'll see `const string`s being used as keys in objects. See https://stackoverflow.com/a/40720612/4370146.
- I didn't `const`-ify object keys in APIs (e.g. url, title, message).
