### PR TITLE
I18 and bug fixes

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,26 @@
+{
+    "extensionDescription": {
+        "message": "Load a random page from your bookmarks!"
+    },
+    "extensionName": {
+        "message": "WebMark"
+    },
+    "folderEmpty": {
+        "message": "The folder is empty. Save some pages!"
+    },
+    "folderName": {
+        "message": "WebMark"
+    },
+    "loadButton": {
+        "message": "Load a random web page"
+    },
+    "pageAlreadyExists": {
+        "message": "The page is already in the folder."
+    },
+    "saveButton": {
+        "message": "Save this web page"
+    },
+    "saveSuccessful": {
+        "message": "Page was saved successfully."
+    }
+}

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -1,0 +1,26 @@
+{
+    "extensionDescription": {
+        "message": "저장해 둔 페이지를 무작위로 불러오세요."
+    },
+    "extensionName": {
+        "message": "웹마크"
+    },
+    "folderEmpty": {
+        "message": "페이지를 먼저 저장해 보세요."
+    },
+    "folderName": {
+        "message": "웹마크"
+    },
+    "loadButton": {
+        "message": "불러오기"
+    },
+    "pageAlreadyExists": {
+        "message": "이미 저장된 페이지예요."
+    },
+    "saveButton": {
+        "message": "저장하기"
+    },
+    "saveSuccessful": {
+        "message": "성공적으로 저장했어요."
+    }
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,22 +8,6 @@
     "storage",
     "tabs"
   ],
-  "commands": {
-    "save": {
-      "suggested_key": {
-        "default": "Alt+S",
-        "mac": "Alt+S"
-      },
-      "description": "Save this page to bookmark"
-    },
-    "load": {
-      "suggested_key": {
-        "default": "Alt+Q",
-        "mac": "Alt+Q"
-      },
-      "description": "Load a random page from bookmark"
-    }
-  },
   "browser_action": {
     "default_popup": "index.html",
     "default_icon": "images/default.png"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,8 @@
 {
-  "name": "WebMark",
+  "name": "__MSG_extensionName__",
   "version": "0.1.0",
-  "description": "Load a random page from your bookmarks!",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "permissions": [
     "bookmarks",
     "notifications",

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,20 +1,18 @@
 import * as React from "react";
 import PopupButton from "./PopupButton";
 import * as constants from "../constants"
+import ButtonGroup from 'react-bootstrap/ButtonGroup'
 
 class Popup extends React.Component {
     constructor() {
         super(React.Component);
     }
-    popupStyle = {
-        width: "220px",
-    };
     render() {
         return (
-            <div className="popup" style={this.popupStyle}>
+            <ButtonGroup id="buttons" vertical>
                 <PopupButton id="save" text={constants.SAVE_BUTTON_TEXT} />
                 <PopupButton id="load" text={constants.LOAD_BUTTON_TEXT} />
-            </div>
+            </ButtonGroup >
         );
     }
 }

--- a/src/components/PopupButton.tsx
+++ b/src/components/PopupButton.tsx
@@ -14,12 +14,12 @@ class PopupButton extends React.Component<Props> {
         this.id = props.id;
         this.text = props.text;
     }
+    style = {
+        'white-space': 'nowrap'
+    } as React.CSSProperties;
     render() {
-        return (
-            <div className="popupButton">
-                <Button id={this.id} variant="light" block>{this.text}</Button>
-            </div>
-        );
+        return <Button id={this.id} variant="light" style={this.style}
+            block>{this.text}</Button>;
     }
 }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,3 +1,4 @@
+/* global chrome */
 /** Constant string literals in alphabetical order */
 // IDs and keys (user-invisible strings)
 export const FOLDER_ID_KEY: string = 'webmarkFolderId';
@@ -8,10 +9,10 @@ export enum NotificationId {
     SaveSuccessful = 'Save Successful',
 };
 
-// to be used for i18n later (user-visible strings)
-export const FOLDER_EMPTY: string = 'The folder is empty. Save some pages!';
-export const FOLDER_NAME: string = 'WebMark';
-export const LOAD_BUTTON_TEXT: string = 'Load a random web page';
-export const PAGE_ALREADY_EXISTS: string = 'The page is already in the folder.';
-export const SAVE_BUTTON_TEXT: string = 'Save this web page';
-export const SAVE_SUCCESSFUL: string = 'Page was saved successfully.';
+// user-visible strings
+export const FOLDER_EMPTY: string = chrome.i18n.getMessage('folderEmpty');
+export const FOLDER_NAME: string = chrome.i18n.getMessage('folderName');
+export const LOAD_BUTTON_TEXT: string = chrome.i18n.getMessage('loadButton');
+export const PAGE_ALREADY_EXISTS: string = chrome.i18n.getMessage('pageAlreadyExists');
+export const SAVE_BUTTON_TEXT: string = chrome.i18n.getMessage('saveButton');
+export const SAVE_SUCCESSFUL: string = chrome.i18n.getMessage('saveSuccessful');

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -3,11 +3,6 @@
 // IDs and keys (user-invisible strings)
 export const FOLDER_ID_KEY: string = 'webmarkFolderId';
 export const LOAD_HERE_KEY: string = 'loadHere';
-export enum NotificationId {
-    PageAlreadyExists = 'Page Already Exists',
-    FolderEmpty = 'Folder Empty',
-    SaveSuccessful = 'Save Successful',
-};
 
 // user-visible strings
 export const FOLDER_EMPTY: string = chrome.i18n.getMessage('folderEmpty');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -239,21 +239,25 @@ let loadRandomUrlFromFolder = (): void => {
                             }
                             let randomIndex: number = Math.floor(Math.random() * urlList.length);
                             let randomUrl: string = urlList[randomIndex];
-                            chrome.storage.sync.get(
-                                [constants.LOAD_HERE_KEY],
-                                (result) => {
-                                    if (Object.keys(result).length !== 0 && result![constants.LOAD_HERE_KEY]) {
-                                        loadInCurrentTab(randomUrl);
-                                    }
-                                    else {
-                                        loadInNewTab(randomUrl);
-                                    }
-                                }
-                            );
+                            loadPage(randomUrl);
                         }
                     );
                 }
             );
+        }
+    );
+}
+
+let loadPage = (url: string): void => {
+    chrome.storage.sync.get(
+        [constants.LOAD_HERE_KEY],
+        (result) => {
+            if (Object.keys(result).length !== 0 && result![constants.LOAD_HERE_KEY]) {
+                loadInCurrentTab(url);
+            }
+            else {
+                loadInNewTab(url);
+            }
         }
     );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,10 +54,7 @@ var loadClicked = (): void => {
             if (Object.keys(result).length === 0) {
                 console.log('webmarkFolderId not found.');
                 createWebmarkFolder();
-                showNotice(
-                    constants.NotificationId.FolderEmpty,
-                    constants.FOLDER_EMPTY,
-                );
+                showNotice(constants.FOLDER_EMPTY);
                 return;
             }
             console.log('webmarkFolderId found.');
@@ -68,10 +65,7 @@ var loadClicked = (): void => {
                     if (chrome.runtime.lastError) {
                         console.log('webmark folder not found.');
                         createWebmarkFolder();
-                        showNotice(
-                            constants.NotificationId.FolderEmpty,
-                            constants.FOLDER_EMPTY,
-                        );
+                        showNotice(constants.FOLDER_EMPTY);
                         chrome.storage.sync.remove(constants.FOLDER_ID_KEY);
                         return;
                     }
@@ -142,10 +136,7 @@ let saveIfNotAlreadyThere = (webmarkFolderId: string, url: string, title: string
         webmarkFolderId,
         (results: chrome.bookmarks.BookmarkTreeNode[]): void => {
             if (isInTree(url, results)) {
-                showNotice(
-                    constants.NotificationId.PageAlreadyExists,
-                    constants.PAGE_ALREADY_EXISTS,
-                );
+                showNotice(constants.PAGE_ALREADY_EXISTS);
             }
             else {
                 console.log('Same page not found in the folder.');
@@ -163,10 +154,7 @@ let saveWithConfidence = (webmarkFolderId: string, url: string, title: string): 
             'title': title,
         },
         () => {
-            showNotice(
-                constants.NotificationId.SaveSuccessful,
-                constants.SAVE_SUCCESSFUL,
-            );
+            showNotice(constants.SAVE_SUCCESSFUL);
             console.log(url + ' saved to folder.');
         }
     );
@@ -181,10 +169,7 @@ let loadRandomUrlFromFolder = (webmarkFolderId: string): void => {
                 recursiveUrlCollection(node, urlList);
             }
             if (urlList.length == 0) {
-                showNotice(
-                    constants.NotificationId.FolderEmpty,
-                    constants.FOLDER_EMPTY,
-                );
+                showNotice(constants.FOLDER_EMPTY);
                 return;
             }
             let randomIndex: number = Math.floor(Math.random() * urlList.length);
@@ -219,9 +204,9 @@ let recursiveUrlCollection = (bookmark: chrome.bookmarks.BookmarkTreeNode, urlLi
     }
 }
 
-var showNotice = (notificationId: constants.NotificationId, title: string, message: string = ''): void => {
+var showNotice = (title: string, message: string = ''): void => {
     chrome.notifications.create(
-        notificationId, // prevents duplicate notifcations (only keeps the most recent one)
+        // notificationId intentionally not sent
         {
             'type': 'basic', // required
             'iconUrl': 'images/default.png', // required
@@ -233,7 +218,7 @@ var showNotice = (notificationId: constants.NotificationId, title: string, messa
             console.log(notificationId + ' notification sent.');
         }
     );
-    console.log('Showed message ("' + message + '") to user.');
+    console.log('Showed message ("' + title + '") to user.');
 }
 
 var loadInCurrentTab = (url: string): void => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -230,6 +230,13 @@ let loadRandomUrlFromFolder = (): void => {
                             for (let node of bookmarkTreeNodes) {
                                 recursiveUrlCollection(node, urlList);
                             }
+                            if (urlList.length == 0) {
+                                showNotice(
+                                    constants.NotificationId.FolderEmpty,
+                                    constants.FOLDER_EMPTY,
+                                );
+                                return;
+                            }
                             let randomIndex: number = Math.floor(Math.random() * urlList.length);
                             let randomUrl: string = urlList[randomIndex];
                             chrome.storage.sync.get(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,13 +122,14 @@ let getCurrentUrlAndSave = (webmarkFolderId: string) => {
 }
 
 let isInTree = (url: string, nodes: chrome.bookmarks.BookmarkTreeNode[]): boolean => {
-    let node: chrome.bookmarks.BookmarkTreeNode;
     while (nodes.length > 0) {
-        node = nodes.pop()!;
-        if (node.url && node.url == url) {
-            return true;
-        } else if (node.children && node.children.length) {
-            for (let child of nodes) {
+        let node: chrome.bookmarks.BookmarkTreeNode = nodes.pop()!;
+        if (node.url) { // bookmark
+            if (node.url == url) {
+                return true;
+            }
+        } else if (node.children) { // folder and has children
+            for (let child of node.children) {
                 nodes.push(child);
             }
         }


### PR DESCRIPTION
## How to test i18n
#### 1. Follow the instruction from https://developer.chrome.com/extensions/i18n#win-shortcut, copy and pasted below:
To create and use a shortcut that launches Google Chrome with a particular locale:

1 Make a copy of the Google Chrome shortcut that's already on your desktop.
2. Rename the new shortcut to match the new locale.
3. Change the shortcut's properties so that the Target field specifies the --lang and --user-data-dir flags. The target should look something like this:
`path_to_chrome.exe --lang=locale --user-data-dir=c:\locale_profile_dir`
***For me it looks like this: "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --lang=ko --user-data-dir=c:\chrome-profile-ko***
4. Launch Google Chrome by double-clicking the shortcut.
For example, to create a shortcut that launches Google Chrome in Spanish (es), you might create a shortcut named chrome-es that has the following target:
`path_to_chrome.exe --lang=es --user-data-dir=c:\chrome-profile-es`
You can create as many shortcuts as you like, making it easy to test in multiple languages. For example:
`path_to_chrome.exe --lang=en --user-data-dir=c:\chrome-profile-en`
`path_to_chrome.exe --lang=en_GB --user-data-dir=c:\chrome-profile-en_GB`
`path_to_chrome.exe --lang=ko --user-data-dir=c:\chrome-profile-ko`

#### 2. Open the shortcut with a different locale and log in with your Google account.
#### 3. Go to chrome://extensions/, enable Developer Mode... You know everything from here.

##  Other issues
- Contributing translations is easy. If you see the directory structure and the `messages.json` files, you'll know what to do.