### PR TITLE
Add guard statements

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,22 +107,8 @@ let getCurrentUrlAndSave = (webmarkFolderId: string) => {
     chrome.tabs.query(
         { active: true, currentWindow: true },
         ([currentTab]) => {
-            // TODO: find better way to sanitize input 
-            // Making parameters that has type string|undefined to be optional does not solve this issue here.
-            // both currentTab.url and currentTab.title are string|undefined, so I cannot assign it to thisTabUrl and thisTabTitle.
-            // Why would changing parameters to optional solve this problem?
-            // Wrong 
-            // const thisTabUrl: string | undefined = currentTab.url;
-            // const thisTabTitle: string | undefined = currentTab.title;
-
-            // Correct
-            // const thisTabUrl: string = (currentTab.url === undefined) ? "https://example.com/error" : currentTab.url;
-            // const thisTabTitle: string = (currentTab.title === undefined) ? "read later" : currentTab.title;
-
-            // Also correct 
             const thisTabUrl: string | undefined = currentTab.url;
             const thisTabTitle: string | undefined = currentTab.title;
-
             saveIfNotAlreadyThere(webmarkFolderId, thisTabUrl, thisTabTitle);
         }
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,12 +112,16 @@ let getCurrentUrlAndSave = (webmarkFolderId: string) => {
             // both currentTab.url and currentTab.title are string|undefined, so I cannot assign it to thisTabUrl and thisTabTitle.
             // Why would changing parameters to optional solve this problem?
             // Wrong 
-            // const thisTabUrl: string = currentTab.url;
-            // const thisTabTitle: string = currentTab.title;
+            // const thisTabUrl: string | undefined = currentTab.url;
+            // const thisTabTitle: string | undefined = currentTab.title;
 
             // Correct
-            const thisTabUrl: string = (currentTab.url === undefined) ? "https://example.com/error" : currentTab.url;
-            const thisTabTitle: string = (currentTab.title === undefined) ? "read later" : currentTab.title;
+            // const thisTabUrl: string = (currentTab.url === undefined) ? "https://example.com/error" : currentTab.url;
+            // const thisTabTitle: string = (currentTab.title === undefined) ? "read later" : currentTab.title;
+
+            // Also correct 
+            const thisTabUrl: string | undefined = currentTab.url;
+            const thisTabTitle: string | undefined = currentTab.title;
 
             saveIfNotAlreadyThere(webmarkFolderId, thisTabUrl, thisTabTitle);
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,15 +107,24 @@ let getCurrentUrlAndSave = (webmarkFolderId: string) => {
     chrome.tabs.query(
         { active: true, currentWindow: true },
         ([currentTab]) => {
-            //TODO: find better way to sanitize input 
+            // TODO: find better way to sanitize input 
+            // Making parameters that has type string|undefined to be optional does not solve this issue here.
+            // both currentTab.url and currentTab.title are string|undefined, so I cannot assign it to thisTabUrl and thisTabTitle.
+            // Why would changing parameters to optional solve this problem?
+            // Wrong 
+            // const thisTabUrl: string = currentTab.url;
+            // const thisTabTitle: string = currentTab.title;
+
+            // Correct
             const thisTabUrl: string = (currentTab.url === undefined) ? "https://example.com/error" : currentTab.url;
             const thisTabTitle: string = (currentTab.title === undefined) ? "read later" : currentTab.title;
+
             saveIfNotAlreadyThere(webmarkFolderId, thisTabUrl, thisTabTitle);
         }
     );
 }
 
-let isInTree = (url: string, nodes: chrome.bookmarks.BookmarkTreeNode[]): boolean => {
+let isInTree = (nodes: chrome.bookmarks.BookmarkTreeNode[], url?: string): boolean => {
     while (nodes.length > 0) {
         let node: chrome.bookmarks.BookmarkTreeNode = nodes.pop()!;
         if (node.url) { // bookmark
@@ -131,11 +140,11 @@ let isInTree = (url: string, nodes: chrome.bookmarks.BookmarkTreeNode[]): boolea
     return false;
 }
 
-let saveIfNotAlreadyThere = (webmarkFolderId: string, url: string, title: string): void => {
+let saveIfNotAlreadyThere = (webmarkFolderId: string, url?: string, title?: string): void => {
     chrome.bookmarks.getSubTree(
         webmarkFolderId,
         (results: chrome.bookmarks.BookmarkTreeNode[]): void => {
-            if (isInTree(url, results)) {
+            if (isInTree(results, url)) {
                 showNotice(constants.PAGE_ALREADY_EXISTS);
             }
             else {
@@ -146,7 +155,7 @@ let saveIfNotAlreadyThere = (webmarkFolderId: string, url: string, title: string
     );
 }
 
-let saveWithConfidence = (webmarkFolderId: string, url: string, title: string): void => {
+let saveWithConfidence = (webmarkFolderId: string, url?: string, title?: string): void => {
     chrome.bookmarks.create(
         {
             'parentId': webmarkFolderId,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,14 +107,14 @@ let getCurrentUrlAndSave = (webmarkFolderId: string) => {
     chrome.tabs.query(
         { active: true, currentWindow: true },
         ([currentTab]) => {
-            const thisTabUrl: string | undefined = currentTab.url;
-            const thisTabTitle: string | undefined = currentTab.title;
+            const thisTabUrl: string = currentTab.url!;
+            const thisTabTitle: string = currentTab.title!;
             saveIfNotAlreadyThere(webmarkFolderId, thisTabUrl, thisTabTitle);
         }
     );
 }
 
-let isInTree = (nodes: chrome.bookmarks.BookmarkTreeNode[], url?: string): boolean => {
+let isInTree = (url: string, nodes: chrome.bookmarks.BookmarkTreeNode[]): boolean => {
     while (nodes.length > 0) {
         let node: chrome.bookmarks.BookmarkTreeNode = nodes.pop()!;
         if (node.url) { // bookmark
@@ -130,11 +130,11 @@ let isInTree = (nodes: chrome.bookmarks.BookmarkTreeNode[], url?: string): boole
     return false;
 }
 
-let saveIfNotAlreadyThere = (webmarkFolderId: string, url?: string, title?: string): void => {
+let saveIfNotAlreadyThere = (webmarkFolderId: string, url: string, title: string): void => {
     chrome.bookmarks.getSubTree(
         webmarkFolderId,
         (results: chrome.bookmarks.BookmarkTreeNode[]): void => {
-            if (isInTree(results, url)) {
+            if (isInTree(url, results)) {
                 showNotice(constants.PAGE_ALREADY_EXISTS);
             }
             else {
@@ -145,7 +145,7 @@ let saveIfNotAlreadyThere = (webmarkFolderId: string, url?: string, title?: stri
     );
 }
 
-let saveWithConfidence = (webmarkFolderId: string, url?: string, title?: string): void => {
+let saveWithConfidence = (webmarkFolderId: string, url: string, title: string): void => {
     chrome.bookmarks.create(
         {
             'parentId': webmarkFolderId,


### PR DESCRIPTION
# Overview
First of all, title of PR is a bit misleading. 
In the original code, variables `currentTab.url` and `currentTab.title` had type of `string | undefined`.
So I included a [type guard statements](https://github.com/jeongm-in/webmark/blob/41c6fbd7a7c892b422ee1d39c7afb99ea7c43b2a/src/index.tsx#L111), in an attempt to guarantee the type of `thisTabUrl` and `thisTabTitle` to be `string`. 
In any case where url and title are type `undefined`, these will resolve to "https://example.com/error" and "read later" respectively. 
These "sanitized" url and title string variables are then passed onto other functions for bookmark registration. 
@Bartleby2718 suggested setting url and title as optional variables in functions that use these variables. 

# Changes
As a result
- `saveIfNotAlreadyThere` now takes parameters `webmarkFolderId: string, url?: string, title?: string`.
- `isInTree` now takes parameters `nodes: chrome.bookmarks.BookmarkTreeNode[], url?: string`.
  - `isInTree` originally took parameters `url: string, nodes: chrome.bookmarks.BookmarkTreeNode[]`, but I switched orders because optional parameters cannot precede required parameters.
- `saveWithConfidence` now takes parameters `webmarkFolderId: string, url?: string, title?: string`.

In addition to function parameters, `thisTabUrl` and `thisTabTitle` now have type `string | undefined`. 

# Test
After changing these parameters and variable types, I was afraid what would happen if any of the url or title strings are `undefined`. 

I created sample sites so that I could test the updated extension. 

![title-test](https://user-images.githubusercontent.com/8725873/60774760-b9173300-a0de-11e9-9716-ad5fc89c5f48.png) 

1. [Empty Title Tag](https://jeongm.in/~jeongmin/emptyTitle.html)
  - `<title></title>`
  - Extension saved this website's url as its title.
2. [No Title Tag](https://jeongm.in/~jeongmin/noTitle.html)
  - Extension saved this website's url as its title.
3. [Title Tag](https://jeongm.in/~jeongmin/normalPage.html)
  - `<title>Title</title>`
  - Extension correctly saved this website's title as its title.
 
I also tested what would happen with sites with empty url. 
- Chrome new tabs page, and it correctly saved new tabs page as bookmark. However, new tab page actually has an url of "chrome://newtab".

# Conclusion
- In conclusion, websites with empty or no title tags have their url as titles.  
- I was unable to find how to access a webpage without an url. 
- Another approach to this would be using non null assertion operator `!` after variables `thisTabUrl` and `thisTabTitle` to "force" them to be `string` type. 
