### PR TITLE
Security patch and version 1.0.2

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_extensionName__",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
I received a notification from dependabot that our dependency has security issues #103
Not knowing what `lodash.template` is, I tried to track when this was included in our dependency. 
`lodash` is part of a lot of packages including babel, Typescript and eslint. `lodash.template` is
in  `workbox-build` and a few other packages. 
As the level of this security issue was `severe`, I proceeded to build, test and merge dependabot PR myself.
This PR simply contains version changes in `manifest.json`